### PR TITLE
Add DocC script and build runner

### DIFF
--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -1,0 +1,47 @@
+# This workflow builds publish DocC docs to GitHub Pages.
+# Source: https://maxxfrazer.medium.com/deploying-docc-with-github-actions-218c5ca6cad5
+# Sample: https://github.com/AgoraIO-Community/VideoUIKit-iOS/blob/main/.github/workflows/deploy_docs.yml
+
+name: DocC Runner
+
+on:
+  push:
+    branches: ["master", "docc"]
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+  
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: macos-15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - id: pages
+        name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Select Xcode version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '16.0'
+      - name: Build DocC
+        run: |
+          bash scripts/docc.sh
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '.build/docc'
+      - id: deployment
+        name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "2c23ab3508b532c9d3bfc8841c0831143585a9d09f5a1b652b6a6dd39029bbba",
+  "pins" : [
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
+        "version" : "1.1.4"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "2bc86522d115234d1f588efe2bcb4ce4be8f8b82",
+        "version" : "510.0.3"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/scripts/docc-swiftui-export-rewrite.sh
+++ b/scripts/docc-swiftui-export-rewrite.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# This script can be run with `bash docc-module-replace.sh` from the Terminal.
+
+# It replaces two strings in the SwiftUIX modules, and is used to disable the
+# default exporting of SwiftUI when building the DocC documentation.
+
+# Define the folders to make the replacement in, and the file name
+folders=("Sources/_SwiftUIX" "Sources/SwiftUIX")
+file_name="module.swift"
+
+# Define the string to replace and its replacement
+old_string=$1
+new_string=$2
+
+# Iterate over the folders
+for folder in "${folders[@]}"; do
+
+     # Construct full path to the file
+    file_path="$folder/$file_name"
+    
+    # Check if file exists
+    if [ -f "$file_path" ]; then
+
+        # Create a temporary file
+        temp_file=$(mktemp)
+        
+        # Perform the replacement and output to temporary file
+        sed "s|$old_string|$new_string|g" "$file_path" > "$temp_file"
+
+        # Replace the original file with the modified content
+        mv "$temp_file" "$file_path"
+    else
+        echo "File not found: $file_path"
+    fi
+done

--- a/scripts/docc.sh
+++ b/scripts/docc.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# This script builds docc with SwiftUI module exports disabled.
+
+# Variables
+BUILD_FOLDER=".build"
+DERIVED_FOLDER="$BUILD_FOLDER/derived"
+DOCC_FOLDER="$BUILD_FOLDER/docc"
+
+# Use the script folder to refer to the rewrite script.
+SCRIPT_FOLDER="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+REWRITE="$SCRIPT_FOLDER/docc-swiftui-export-rewrite.sh"
+chmod +x "$REWRITE"
+
+# Build DocC documentation
+swift package resolve;
+xcodebuild docbuild -scheme Swallow -derivedDataPath $DERIVED_FOLDER -destination 'generic/platform=iOS';
+
+# Transform the generated documentation for static hosting
+$(xcrun --find docc) process-archive \
+    transform-for-static-hosting $DERIVED_FOLDER/Build/Products/Debug-iphoneos/Swallow.doccarchive \
+    --output-path $DOCC_FOLDER \
+    --hosting-base-path 'Swallow';
+
+# Inject a redirect script into the empty documentation root
+echo "<script>window.location.href += \"/documentation/swallow\"</script>" > $DOCC_FOLDER/index.html;


### PR DESCRIPTION
This PR makes Swallow generate GitHub Pages hosted DocC documentation on every push to `master` and `docc`.

Since the DocC build takes 25 minutes for Swallow and iOS alone, we should perhaps adjust the runner to only trigger when we push to a `docc` branch.

After merging this, you must adjust the environment permissions, to allow the `docc` branch to build to GitHub Pages:

<img width="1234" alt="image" src="https://github.com/user-attachments/assets/670aff37-6427-46db-af1f-6fbbb3b795cf">
