### PR TITLE
Add DebugLogMethodMacro

### DIFF
--- a/Macros/SwallowMacros/Intramodular/Macros/DebugLogMethodMacro.swift
+++ b/Macros/SwallowMacros/Intramodular/Macros/DebugLogMethodMacro.swift
@@ -1,0 +1,30 @@
+//
+// Copyright (c) Vatsal Manot
+//
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public struct DebugLogMethodMacro: BodyMacro {
+    public static func expansion(
+        of node: SwiftSyntax.AttributeSyntax,
+        providingBodyFor declaration: some SwiftSyntax.DeclSyntaxProtocol & SwiftSyntax.WithOptionalCodeBlockSyntax,
+        in context: some SwiftSyntaxMacros.MacroExpansionContext
+    ) throws -> [SwiftSyntax.CodeBlockItemSyntax] {
+        guard let declaration = declaration.as(FunctionDeclSyntax.self) else {
+            return []
+        }
+
+        guard let originalBody = declaration.body?.statements else {
+            return []
+        }
+        
+        let methodName = declaration.name.text
+        var newBody: [CodeBlockItemSyntax] = [
+            "print(\"Entering method \(raw: methodName)\")"
+        ]
+        newBody.append(contentsOf: originalBody)
+        newBody.append("print(\"Exiting method \(raw: methodName)\")")
+        return newBody
+    }
+}

--- a/Macros/SwallowMacros/module.swift
+++ b/Macros/SwallowMacros/module.swift
@@ -16,6 +16,7 @@ public struct module: CompilerPlugin {
         AddCaseBooleanMacro.self,
         GenerateDuplicateMacro.self,
         GenerateTypeEraserMacro.self,
+        DebugLogMethodMacro.self,
         DeclarationScopeMacro.self,
         HadeanIdentifierMacro.self,
         HashableMacro.self,

--- a/Macros/SwallowMacrosClient/Intramodular/DebugLog.swift
+++ b/Macros/SwallowMacrosClient/Intramodular/DebugLog.swift
@@ -1,0 +1,12 @@
+//
+// Copyright (c) Vatsal Manot
+//
+
+import Swift
+
+@attached(body)
+public macro _DebugLogMethod() = #externalMacro(
+    module: "SwallowMacros",
+    type: "DebugLogMethodMacro"
+)
+

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "139df82584b0c2e40e3c06592b02b670d49373ff25813998dab52d6c9e7c3b7a",
+  "pins" : [
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
+        "version" : "1.1.4"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -46,7 +46,7 @@ var package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-collections", from: "1.1.0"),
-        .package(url: "https://github.com/apple/swift-syntax.git", from: "510.0.0"),
+        .package(url: "https://github.com/apple/swift-syntax.git", from: "600.0.1"),
     ],
     targets: [
         .target(
@@ -203,6 +203,7 @@ var package = Package(
                 "Runtime",
                 "Swallow",
                 "SwallowMacrosClient",
+                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax", condition: .when(platforms: [.macOS])),
                 .target(name: "SwiftSyntaxUtilities", condition: .when(platforms: [.macOS])),
             ],
             path: "Tests/Swallow"

--- a/Tests/Swallow/DebugLogMethodMacroTests.swift
+++ b/Tests/Swallow/DebugLogMethodMacroTests.swift
@@ -1,0 +1,60 @@
+//
+// Copyright (c) Vatsal Manot
+//
+
+import SwallowMacros
+import SwallowMacrosClient
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+final class DebugLogMethodMacroTests: XCTestCase {
+    func testDebugLogMethodMacro() {
+        let testClass = TestClass()
+        // Should print
+        testClass.debugTestOne(x: 10, y: "20")
+        // Shouldn't print
+        testClass.debugTestTwo(x: 20, y: "40")
+    }
+    
+    func testDebugLogMethodMacroExpansion() {
+        assertMacroExpansion(
+            """
+            @_DebugLogMethod
+            func test(x: Int) {
+                let y = x + 1
+            }
+            """,
+            expandedSource: """
+            func test(x: Int) {
+                print("Entering method test")
+                let y = x + 1
+                print("Exiting method test")
+            }
+            """,
+            macros: ["_DebugLogMethod": DebugLogMethodMacro.self]
+        )
+    }
+    
+    func testEmptyFunctionMacroExpansion() {
+        assertMacroExpansion(
+            """
+            @_DebugLogMethod
+            func empty() {
+            }
+            """,
+            expandedSource: """
+            func empty() {
+                print("Entering method empty")
+                print("Exiting method empty")
+            }
+            """,
+            macros: ["_DebugLogMethod": DebugLogMethodMacro.self]
+        )
+    }
+}
+
+fileprivate final class TestClass {
+    @_DebugLogMethod
+    func debugTestOne(x: Int, y: String) {}
+    func debugTestTwo(x: Int, y: String) {}
+}


### PR DESCRIPTION
Adds a macro `@_DebugLogMethod` which automatically adds entry and exit debug print statements to the method it is attached to.

@vmanot Note that using `BodyMacro` type and `@attached(body)` require us to update `swift-syntax` to `600.0.1`.