### PR TITLE
Fix DocC generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,4 +19,4 @@ jobs:
       uses: PreternaturalAI/github-action/preternatural-build@main
       with:
         xcode-version: '16'
-        configuration: 'debug'
+        configurations: 'debug'

--- a/.github/workflows/generate-docc.yml
+++ b/.github/workflows/generate-docc.yml
@@ -1,0 +1,47 @@
+name: Generate Documentation
+on:
+  push:
+    branches: [ master, docc-generation]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  generate:
+    runs-on: ghcr.io/cirruslabs/macos-runner:sonoma
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        ref: documentation
+        fetch-depth: 0
+
+    - name: Configure Git
+      run: |
+        git config --global user.name "GitHub Actions Bot"
+        git config --global user.email "actions@github.com"
+
+    - name: Merge master into documentation
+      run: |
+        git fetch origin master
+        git merge origin/master --no-edit
+
+    - name: Generate Documentation
+      run: |
+        sh ./scripts/generate-docc.sh
+
+    - name: Commit and push if changed
+      run: |
+        git add documentation/
+        if git diff --staged --quiet; then
+          echo "No changes to commit"
+        else
+          git commit -m "Update documentation"
+          git push
+        fi

--- a/.github/workflows/generate-docc.yml
+++ b/.github/workflows/generate-docc.yml
@@ -14,34 +14,23 @@ concurrency:
 jobs:
   generate:
     runs-on: ghcr.io/cirruslabs/macos-runner:sonoma
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
-      with:
-        ref: documentation
-        fetch-depth: 0
-
-    - name: Configure Git
-      run: |
-        git config --global user.name "GitHub Actions Bot"
-        git config --global user.email "actions@github.com"
-
-    - name: Merge master into documentation
-      run: |
-        git fetch origin master
-        git merge origin/master --no-edit
+      uses: actions/checkout@v4
 
     - name: Generate Documentation
       run: |
-        sh ./scripts/generate-docc.sh
+        if ! sh ./scripts/generate-docc.sh; then
+          echo "Documentation generation failed"
+          exit 1
+        fi
 
-    - name: Commit and push if changed
+    - name: Upload to Cloudflare
       run: |
-        git add documentation/
-        if git diff --staged --quiet; then
-          echo "No changes to commit"
-        else
-          git commit -m "Update documentation"
-          git push
+        if ! sh ./scripts/upload_to_cloudflare.sh; then
+          echo "Cloudflare upload failed"
+          exit 1
         fi

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "139df82584b0c2e40e3c06592b02b670d49373ff25813998dab52d6c9e7c3b7a",
+  "originHash" : "97bb612a8302bfa482074b45c5b97c73cd1a99561ef38193cce37e64d4060306",
   "pins" : [
     {
       "identity" : "swift-collections",
@@ -8,6 +8,24 @@
       "state" : {
         "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
         "version" : "1.1.4"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin",
+      "state" : {
+        "revision" : "85e4bb4e1cd62cec64a4b8e769dcefdf0c5b9d64",
+        "version" : "1.4.3"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -47,6 +47,7 @@ var package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-collections", from: "1.1.0"),
         .package(url: "https://github.com/apple/swift-syntax.git", from: "600.0.1"),
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.4.3"),
     ],
     targets: [
         .target(
@@ -238,12 +239,12 @@ private func patchSwiftSyntaxDependency(in package: inout Package) {
     }
     
     for index in 0..<package.targets.count {
-        var target: Target = package.targets[index]
+        let target: Target = package.targets[index]
         var patched: Bool = false
         
         target.dependencies = target.dependencies.compactMap { (dependency: Target.Dependency) -> Target.Dependency? in
             switch dependency {
-                case .productItem(let name, let package, let moduleAliases, let condition):
+                case .productItem(let name, let package, let moduleAliases, _):
                     let targets: Set<String> = [
                         "SwiftSyntax",
                         "SwiftSyntaxMacros",

--- a/scripts/build_documentation_for_targets.sh
+++ b/scripts/build_documentation_for_targets.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+build_documentation_for_targets() {
+    echo_color "$BLUE" "Generating documentation..."
+    target_args=""
+    for target in "${TARGETS[@]}"; do
+        target_args+="--target $target "
+    done
+
+    swift package \
+        --allow-writing-to-directory "$OUTPUT_PATH" \
+        generate-documentation \
+        --transform-for-static-hosting \
+        --disable-indexing \
+        --output-path "$OUTPUT_PATH" \
+        $target_args \
+        --enable-experimental-combined-documentation
+}
+build_documentation_for_targets

--- a/scripts/create_index_html.sh
+++ b/scripts/create_index_html.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+create_index_html() {
+    echo '<!DOCTYPE html>
+<html>
+<head>
+    <title>Documentation</title>
+    <link href="../css/index.3a335429.css" rel="stylesheet">
+    <style>
+        body { 
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto;
+            max-width: 800px;
+            margin: 40px auto;
+            padding: 0 20px;
+        }
+        .module-list {
+            display: grid;
+            gap: 20px;
+            padding: 0;
+        }
+        .module-card {
+            border: 1px solid #eee;
+            border-radius: 8px;
+            padding: 20px;
+            list-style: none;
+            transition: all 0.2s;
+        }
+        .module-card:hover {
+            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+        }
+        h1 { color: #333; }
+        a { 
+            color: #0066cc;
+            text-decoration: none;
+        }
+    </style>
+</head>
+<body>
+    <h1>Swallow Documentation</h1>
+    <ul class="module-list">' > "${INDEX_HTML_PATH}"
+    
+    for target in "${TARGETS[@]}"; do
+        echo "        <li class=\"module-card\"><a href=\"${target}/\">${target}</a></li>" >> "${INDEX_HTML_PATH}"
+    done
+    
+    echo "    </ul>
+</body>
+</html>" >> "${INDEX_HTML_PATH}"
+}
+create_index_html

--- a/scripts/echo_color.sh
+++ b/scripts/echo_color.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+RED="\033[0;31m"
+GREEN="\033[0;32m"
+BLUE="\033[0;34m"
+YELLOW="\033[0;33m"
+NC="\033[0m"
+
+echo_color() {
+	color="$1"
+	message="$2"
+	printf "%b%s%b\n" "$color" "$message" "$NC"
+}

--- a/scripts/extract_targets.sh
+++ b/scripts/extract_targets.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+extract_targets() {
+    local temp_script="/tmp/parse_package.swift"
+    local package_dir="$1"
+    
+    # Change to the package directory if provided
+    if [ -n "$package_dir" ]; then
+        cd "$package_dir" || { echo "Error: Could not change to directory $package_dir" >&2; return 1; }
+    fi
+    
+    if [ ! -f "Package.swift" ]; then
+        echo "Error: Package.swift not found in current directory $(pwd)" >&2
+        return 1
+    fi
+    
+    cat > "$temp_script" << 'EOF'
+import Foundation
+
+guard let packageContent = try? String(contentsOfFile: "Package.swift", encoding: .utf8) else {
+    print("Error: Could not read Package.swift")
+    exit(1)
+}
+
+let targetPattern = #"\.target\(\s*name:\s*"([^"]+)""#
+let regex = try! NSRegularExpression(pattern: targetPattern)
+let range = NSRange(packageContent.startIndex..<packageContent.endIndex, in: packageContent)
+let matches = regex.matches(in: packageContent, range: range)
+
+let targets = matches.compactMap { match -> String? in
+    guard let range = Range(match.range(at: 1), in: packageContent) else { return nil }
+    let target = String(packageContent[range])
+    return target.hasSuffix("Tests") ? nil : target
+}
+
+let uniqueTargets = Array(Set(targets)).sorted().reversed()
+for target in uniqueTargets {
+    print(target)
+}
+EOF
+
+    if ! swift "$temp_script"; then
+        echo "Error: Failed to execute Swift script" >&2
+        rm "$temp_script"
+        return 1
+    fi
+    
+    rm "$temp_script"
+}
+
+# Get the package path from the first argument
+PACKAGE_DIR="$1"
+
+# Run extract_targets with the package directory
+if ! TARGETS_OUTPUT=$(extract_targets "$PACKAGE_DIR"); then
+    echo "Failed to extract targets" >&2
+    exit 1
+fi
+
+# Convert output to array (macOS compatible way)
+TARGETS=()
+while IFS= read -r line; do
+    if [ -n "$line" ]; then
+        TARGETS+=("$line")
+    fi
+done <<< "$TARGETS_OUTPUT"
+
+if [ ${#TARGETS[@]} -eq 0 ]; then
+    echo "Error: No targets found in Package.swift" >&2
+    exit 1
+fi
+
+echo "Found the following targets:"
+printf '%s\n' "${TARGETS[@]}"
+
+# Export the TARGETS array
+export TARGETS

--- a/scripts/generate-docc.sh
+++ b/scripts/generate-docc.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# To generate documentation on your local machine, run this script from the project root directory.
+# After successful generation, to serve the documentation locally:
+#   1. Navigate to project-root/documentation folder
+#   2. Run: npx http-server -p 8000 --cors -c-1
+#   3. View documentation in browser at: http://127.0.0.1:8000/documentation/
+
+set -e
+PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$PROJECT_DIR"
+
+OUTPUT_PATH="$PROJECT_DIR/documentation"
+INDEX_HTML_PATH="$PROJECT_DIR/documentation/documentation/index.html"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/echo_color.sh" "."
+source "$SCRIPT_DIR/extract_targets.sh" "."
+source "$SCRIPT_DIR/setup_work_directory.sh" "."
+source "$SCRIPT_DIR/build_documentation_for_targets.sh" "."
+source "$SCRIPT_DIR/create_index_html.sh" "."
+
+# Create .nojekyll file for GitHub Pages
+# .nojekyll file is necessary if you plan to host the documentation on GitHub Pages.
+# Without it, GitHub Pages (which uses Jekyll by default) will ignore folders that start with underscores (_).
+touch "${OUTPUT_PATH}/.nojekyll"
+echo_color "$GREEN" "Documentation generation complete!"

--- a/scripts/setup_work_directory.sh
+++ b/scripts/setup_work_directory.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+setup_work_directory() {
+  echo_color "$RED" "Setting up work directory..."
+
+  rm -rf "$OUTPUT_PATH"
+  mkdir -p "$OUTPUT_PATH"
+
+  end_time=$(date +%s)
+  elapsed_time=$((end_time - start_time))
+}
+
+setup_work_directory

--- a/scripts/upload_to_cloudflare.sh
+++ b/scripts/upload_to_cloudflare.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+cd ~/Preternatural/Swallow/documentation || { echo "Failed to change directory"; exit 1; }
+echo "Current directory: $(pwd)"
+
+total_files=$(find . -type f | wc -l)
+echo "Found $total_files files to upload"
+
+counter=0
+find . -type f | while read file; do
+    counter=$((counter + 1))
+    cleaned_file=${file#./}
+    printf "[%d/%d] Uploading: %s\n" "$counter" "$total_files" "$cleaned_file"
+    npx wrangler r2 object put "swallowdocs/documentation/$cleaned_file" --file "$file" > /dev/null 2>&1
+done


### PR DESCRIPTION
To generate documentation on your local machine, run `./scripts/generate-docc.sh` from the project root directory. After successful generation, to serve the documentation locally:
1. Navigate to project-root/documentation folder
2. Run: npx http-server -p 8000 --cors -c-1
3. View documentation in browser at: http://127.0.0.1:8000/documentation/


https://github.com/user-attachments/assets/e767941b-0e5e-42e9-a5cf-475b1688f308

