### PR TITLE
Created TransactionKey Macro

### DIFF
--- a/Macros/SwallowMacros/Intramodular/TransactionKeyMacro.swift
+++ b/Macros/SwallowMacros/Intramodular/TransactionKeyMacro.swift
@@ -1,0 +1,85 @@
+//
+//  File.swift
+//  Swallow
+//
+//  Created by Yasir on 05/05/25.
+//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct TransactionKeyMacro: AccessorMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingAccessorsOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [AccessorDeclSyntax] {
+        // Ensure we're dealing with a variable declaration
+        guard let varDecl = declaration.as(VariableDeclSyntax.self),
+              let binding = varDecl.bindings.first,
+              let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text,
+              let _ = binding.typeAnnotation?.type else {
+            throw MacroError("@TransactionKey can only be applied to a variable with a type annotation")
+        }
+        
+        // Extract default value if present
+        let defaultValueExpr = binding.initializer?.value
+        
+        // Create the key struct name
+        let keyStructName = "TransactionKey_\(identifier)"
+        
+        // Create getter and setter
+        let getter = """
+        get {
+          self[\(keyStructName).self]
+        }
+        """
+        
+        let setter = """
+        set {
+          self[\(keyStructName).self] = newValue
+        }
+        """
+        
+        // Create the accessors
+        return [
+            AccessorDeclSyntax(stringLiteral: getter),
+            AccessorDeclSyntax(stringLiteral: setter)
+        ]
+    }
+}
+
+extension TransactionKeyMacro: PeerMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        guard let varDecl = declaration.as(VariableDeclSyntax.self),
+              let binding = varDecl.bindings.first,
+              let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text,
+              let type = binding.typeAnnotation?.type else {
+            throw MacroError("@TransactionKey must be applied to a variable with a type annotation")
+        }
+
+        let defaultValueExpr = binding.initializer?.value
+        let defaultValueText = defaultValueExpr?.description ?? "nil"
+
+        let keyStruct = """
+        private struct TransactionKey_\(identifier): TransactionKey {
+            static let defaultValue: \(type) = \(defaultValueText)
+        }
+        """
+
+        return [DeclSyntax(stringLiteral: keyStruct)]
+    }
+}
+
+struct MacroError: Error, CustomStringConvertible {
+    let description: String
+    
+    init(_ description: String) {
+        self.description = description
+    }
+}

--- a/Macros/SwallowMacros/Intramodular/TransactionKeyMacro.swift
+++ b/Macros/SwallowMacros/Intramodular/TransactionKeyMacro.swift
@@ -8,6 +8,7 @@
 import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
+import SwiftSyntaxUtilities
 
 public struct TransactionKeyMacro: AccessorMacro {
     public static func expansion(
@@ -20,7 +21,7 @@ public struct TransactionKeyMacro: AccessorMacro {
               let binding = varDecl.bindings.first,
               let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text,
               let _ = binding.typeAnnotation?.type else {
-            throw MacroError("@TransactionKey can only be applied to a variable with a type annotation")
+            throw AnyDiagnosticMessage(message: "@TransactionKey can only be applied to a variable with a type annotation")
         }
         
         // Extract default value if present
@@ -60,7 +61,7 @@ extension TransactionKeyMacro: PeerMacro {
               let binding = varDecl.bindings.first,
               let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text,
               let type = binding.typeAnnotation?.type else {
-            throw MacroError("@TransactionKey must be applied to a variable with a type annotation")
+            throw AnyDiagnosticMessage(message: "@TransactionKey must be applied to a variable with a type annotation")
         }
 
         let defaultValueExpr = binding.initializer?.value
@@ -73,13 +74,5 @@ extension TransactionKeyMacro: PeerMacro {
         """
 
         return [DeclSyntax(stringLiteral: keyStruct)]
-    }
-}
-
-struct MacroError: Error, CustomStringConvertible {
-    let description: String
-    
-    init(_ description: String) {
-        self.description = description
     }
 }

--- a/Macros/SwallowMacros/Intramodular/TransactionKeyMacro.swift
+++ b/Macros/SwallowMacros/Intramodular/TransactionKeyMacro.swift
@@ -16,34 +16,27 @@ public struct TransactionKeyMacro: AccessorMacro {
         providingAccessorsOf declaration: some DeclSyntaxProtocol,
         in context: some MacroExpansionContext
     ) throws -> [AccessorDeclSyntax] {
-        // Ensure we're dealing with a variable declaration
-        guard let varDecl = declaration.as(VariableDeclSyntax.self),
-              let binding = varDecl.bindings.first,
-              let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text,
+        guard let varDecl: VariableDeclSyntax = declaration.as(VariableDeclSyntax.self),
+              let binding: PatternBindingListSyntax.Element = varDecl.bindings.first,
+              let identifier: TokenSyntax = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier,
               let _ = binding.typeAnnotation?.type else {
             throw AnyDiagnosticMessage(message: "@TransactionKey can only be applied to a variable with a type annotation")
         }
+                
+        let keyStructName: String = "TransactionKey_\(identifier.text)"
         
-        // Extract default value if present
-        let defaultValueExpr = binding.initializer?.value
-        
-        // Create the key struct name
-        let keyStructName = "TransactionKey_\(identifier)"
-        
-        // Create getter and setter
-        let getter = """
+        let getter: String = """
         get {
           self[\(keyStructName).self]
         }
         """
         
-        let setter = """
+        let setter: String = """
         set {
           self[\(keyStructName).self] = newValue
         }
         """
         
-        // Create the accessors
         return [
             AccessorDeclSyntax(stringLiteral: getter),
             AccessorDeclSyntax(stringLiteral: setter)

--- a/Macros/SwallowMacrosClient/Intramodular/TransactionKeyMacro-client.swift
+++ b/Macros/SwallowMacrosClient/Intramodular/TransactionKeyMacro-client.swift
@@ -1,0 +1,12 @@
+//
+//  File.swift
+//  Swallow
+//
+//  Created by Yasir on 05/05/25.
+//
+
+import Foundation
+
+@attached(accessor, names: named(get), named(set))
+@attached(peer, names: arbitrary)
+public macro TransactionKey() = #externalMacro(module: "SwallowMacros", type: "TransactionKeyMacro")

--- a/Tests/Swallow/TransactionKeyMacroTests.swift
+++ b/Tests/Swallow/TransactionKeyMacroTests.swift
@@ -1,0 +1,45 @@
+//
+//  File.swift
+//  Swallow
+//
+//  Created by Yasir on 06/05/25.
+//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import SwallowMacros
+import XCTest
+
+final class TransactionKeyMacroTests: XCTestCase {
+    static let macroNameIdentifier = "TransactionKey"
+    
+    func testTransactionKeyMacro() throws {
+            assertMacroExpansion(
+                    """
+                    extension Transaction {
+                        @TransactionKey
+                        static var customValue: Bool = false
+                    }
+                    """,
+                    expandedSource: """
+                    extension Transaction {
+                        static var customValue: Bool {
+                            get {
+                              self[TransactionKey_customValue.self]
+                            }
+                            set {
+                              self[TransactionKey_customValue.self] = newValue
+                            }
+                        }
+                    
+                        private struct TransactionKey_customValue: TransactionKey {
+                            static let defaultValue: Bool  = false
+                        }
+                    }
+                    """,
+                    macros: [TransactionKeyMacroTests.macroNameIdentifier: TransactionKeyMacro.self]
+            )
+        }
+}


### PR DESCRIPTION
Introduced a @TransactionKey macro for easy transaction key generation. 

Usage:
```
extension Transaction {
    @TransactionKey
    var customValue: Bool = false
}

```