### PR TITLE
Deprecate ObjCObject subscripts

### DIFF
--- a/Sources/Runtime/Intermodular/Helpers/ObjectiveC/ObjectiveC.ObjCObject.swift
+++ b/Sources/Runtime/Intermodular/Helpers/ObjectiveC/ObjectiveC.ObjCObject.swift
@@ -31,6 +31,7 @@ extension ObjCObject {
 }
 
 extension ObjCObject {
+    @available(*, deprecated, message: "It occurs memory leak when ivar has non-'OCL_Strong' type. Also if value is bigger than sizeof(id), it will occur memory corruption.")
     public subscript(instanceVariable value: ObjCInstanceVariable) -> Any? {
         get {
             return object_getIvar(self, value.value)
@@ -39,6 +40,7 @@ extension ObjCObject {
         }
     }
     
+    @available(*, deprecated, message: "If value is bigger than sizeof(id), it will occur memory corruption.")
     public subscript(instanceVariableNamed name: String) -> Any? {
         get {
             return objCClass[instanceVariableNamed: name].flatMap({ self[instanceVariable: $0] })


### PR DESCRIPTION
`ObjCObject.subscript(instanceVariable:)` and `ObjCObject.subscript(instanceVariableNamed:)` should be deprecated and removed.

In Objective-C if you set object on property, you should release old value and retain (or copy) new value like this.

```objc
- (void)setMyValue:(id<NSObject>)myValue {
    [_myValue release];
    _myValue = [myValue retain]; // or -copy
}
```

`object_setIvar` do this with `objc_storeStrong` when `objc_ivar_memory_management_t` is equal to `objc_ivar_memoryStrong`. https://github.com/apple-oss-distributions/objc4/blob/f126469408dc82bd3f327217ae678fd0e6e3b37c/runtime/objc-class.mm#L362

llvm sets `objc_ivar_memoryStrong` on its ivar when ARC is enabled, and property has `strong`, `retain` attribute. https://github.com/llvm/llvm-project/blob/f2e244f443c99f814216bef37a82f1b8d3e5975d/clang/lib/Sema/SemaObjCProperty.cpp#L742

If ivar definition is created with non-ARC environment, then ivar won't have `objc_ivar_memoryStrong` management (even if it has `strong` attribute). That means if you use `object_setIvar` it won't call `-release` on old value. https://github.com/apple-oss-distributions/objc4/blob/f126469408dc82bd3f327217ae678fd0e6e3b37c/runtime/objc-class.mm#L363

```objc
#import <Foundation/Foundation.h>
#include <objc/runtime.h>

@interface FooObject : NSObject
@property (strong, nonatomic) id<NSObject> strongObject;
@property (retain, atomic) id<NSObject> retainedObject;
@end

@implementation FooObject
#if !__has_feature(objc_arc)
- (void)dealloc {
    [_strongObject release];
    [_retainedObject release];
    [super dealloc];
}
#endif
@end


int main(int argc, const char * argv[]) {
    @autoreleasepool {
        FooObject *fooObject = [FooObject new];
        
        __weak NSObject *first_strongObject;
        __weak NSObject *first_retainedObject;
        @autoreleasepool {
            NSObject *strongObject = [NSObject new];
            fooObject.strongObject = strongObject;
            first_strongObject = strongObject;
#if !__has_feature(objc_arc)
            [strongObject release];
#endif
            
            NSObject *retainedObject = [NSObject new];
            fooObject.retainedObject = retainedObject;
            first_retainedObject = retainedObject;
#if !__has_feature(objc_arc)
            [retainedObject release];
#endif
        }
        
        assert(first_strongObject != nil);
        assert(first_retainedObject != nil);
        
        {
            unsigned int ivarsCount;
            Ivar *ivars = class_copyIvarList([FooObject class], &ivarsCount);
            
            for (unsigned int i = 0; i < ivarsCount; i++) @autoreleasepool {
                Ivar ivar = ivars[i];
                const char *name = ivar_getName(ivar);
                if (strcmp(name, "_strongObject") == 0) {
                    object_setIvar(fooObject, ivar, nil);
                } else if (strcmp(name, "_retainedObject") == 0) {
                    object_setIvar(fooObject, ivar, nil);
                }
            }
            
            free(ivars);
        }
        
        // These tests fail on non_ARC environment
        assert(first_strongObject == nil);
        assert(first_retainedObject == nil);
        
#if !__has_feature(objc_arc)
        [fooObject release];
#endif
    }
    return EXIT_SUCCESS;
}
```

Also `object_setIvar` and `object_getIvar` only works when size of value is equal to `sizeof(id)`.

Instead, you should use `ivar_getOffset` directly and [`Unmanged`](https://developer.apple.com/documentation/swift/unmanaged) to manage reference count manually. https://github.com/vmanot/Swallow/blob/685a3ddfe700105557cf28e9df08a2ea315e5868/Sources/Runtime/Intermodular/Helpers/ObjectiveC/ObjectiveC.ObjCInstanceVariable.swift#L19